### PR TITLE
Addresses missing citeproc-php library issue (ISLE issue 271)

### DIFF
--- a/isle-drush_make/islandora.drush.make
+++ b/isle-drush_make/islandora.drush.make
@@ -87,3 +87,7 @@ libraries[islandora_internet_archive_bookreader][download][type] = "get"
 libraries[islandora_internet_archive_bookreader][download][url] = "https://github.com/Islandora/internet_archive_bookreader/archive/master.zip"
 libraries[islandora_internet_archive_bookreader][directory_name] = "bookreader"
 libraries[islandora_internet_archive_bookreader][type] = "library"
+
+; needed for islandora_scholar
+libraries[citeproc-php][download][type] = "git"
+libraries[citeproc-php][download][url] = "https://github.com/Islandora/citeproc-php.git"


### PR DESCRIPTION
Adds Islandora fork of citeproc-php library to the libraries installed in the drupal site.  Addresses issue: https://github.com/Islandora-Collaboration-Group/ISLE/issues/271